### PR TITLE
Rewrite API to include Organization Name.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,32 +9,9 @@ pipeline {
         stage('Publish') {
             when { branch 'master' }
             steps {
-                sh "docker tag ${GIT_COMMIT} fintlabsacr.azurecr.io/test-runner:build.${BUILD_NUMBER}"
+                sh "docker tag ${GIT_COMMIT} fintlabsacr.azurecr.io/test-runner:latest"
                 withDockerRegistry([credentialsId: 'fintlabsacr.azurecr.io', url: 'https://fintlabsacr.azurecr.io']) {
-                    sh "docker push fintlabsacr.azurecr.io/test-runner:build.${BUILD_NUMBER}"
-                }
-            }
-        }
-        stage('Publish PR') {
-            when { changeRequest() }
-            steps {
-                sh "docker tag ${GIT_COMMIT} fintlabsacr.azurecr.io/test-runner:${BRANCH_NAME}.${BUILD_NUMBER}"
-                withDockerRegistry([credentialsId: 'fintlabsacr.azurecr.io', url: 'https://fintlabsacr.azurecr.io']) {
-                    sh "docker push fintlabsacr.azurecr.io/test-runner:${BRANCH_NAME}.${BUILD_NUMBER}"
-                }
-            }
-        }
-        stage('Publish Version') {
-            when {
-                tag pattern: "v\\d+\\.\\d+\\.\\d+(-\\w+-\\d+)?", comparator: "REGEXP"
-            }
-            steps {
-                script {
-                    VERSION = TAG_NAME[1..-1]
-                }
-                sh "docker tag ${GIT_COMMIT} fintlabsacr.azurecr.io/test-runner:${VERSION}"
-                withDockerRegistry([credentialsId: 'fintlabsacr.azurecr.io', url: 'https://fintlabsacr.azurecr.io']) {
-                    sh "docker push fintlabsacr.azurecr.io/test-runner:${VERSION}"
+                    sh "docker push fintlabsacr.azurecr.io/test-runner:latest"
                 }
             }
         }

--- a/src/main/java/no/fint/testrunner/controller/AuthInitController.java
+++ b/src/main/java/no/fint/testrunner/controller/AuthInitController.java
@@ -34,18 +34,19 @@ public class AuthInitController {
     @Autowired
     private OAuthRestTemplateFactory templateFactory;
 
-    @PostMapping("/init/{clientDn}")
+    @PostMapping("/init/{clientName}")
     public ResponseEntity<Void> authorize(@PathVariable String orgName,
-                                          @PathVariable String clientDn,
+                                          @PathVariable String clientName,
                                           @RequestBody TestRequest testRequest) {
 
         if (!Pwf.isPwf(testRequest.getBaseUrl())) {
+            log.info("Auth Init, {}, {}", orgName, clientName);
             boolean isExpired = Optional.ofNullable(accessTokenRepository.getAccessToken(orgName)).map(OAuth2AccessToken::isExpired).orElse(true);
             if (!isExpired) {
                 return ResponseEntity.noContent().build();
             }
 
-            Client client = clientService.getClientByDn(clientDn).orElseThrow(SecurityException::new);
+            Client client = clientService.getClient(clientName, orgName).orElseThrow(SecurityException::new);
 
             String password = UUID.randomUUID().toString().toLowerCase();
             clientService.resetClientPassword(client, password);

--- a/src/main/java/no/fint/testrunner/controller/AuthInitController.java
+++ b/src/main/java/no/fint/testrunner/controller/AuthInitController.java
@@ -22,7 +22,7 @@ import java.util.UUID;
 @RestController
 @CrossOrigin
 @Api(value = "Basic Tests")
-@RequestMapping("/api/tests/auth")
+@RequestMapping("/api/tests/{orgName}/auth")
 public class AuthInitController {
 
     @Autowired
@@ -34,16 +34,18 @@ public class AuthInitController {
     @Autowired
     private OAuthRestTemplateFactory templateFactory;
 
-    @PostMapping("/init")
-    public ResponseEntity<Void> authorize(@RequestBody TestRequest testRequest) {
+    @PostMapping("/init/{clientDn}")
+    public ResponseEntity<Void> authorize(@PathVariable String orgName,
+                                          @PathVariable String clientDn,
+                                          @RequestBody TestRequest testRequest) {
 
         if (!Pwf.isPwf(testRequest.getBaseUrl())) {
-            boolean isExpired = Optional.ofNullable(accessTokenRepository.getAccessToken(testRequest.getClient())).map(OAuth2AccessToken::isExpired).orElse(true);
+            boolean isExpired = Optional.ofNullable(accessTokenRepository.getAccessToken(orgName)).map(OAuth2AccessToken::isExpired).orElse(true);
             if (!isExpired) {
                 return ResponseEntity.noContent().build();
             }
 
-            Client client = clientService.getClientByDn(testRequest.getClient()).orElseThrow(SecurityException::new);
+            Client client = clientService.getClientByDn(clientDn).orElseThrow(SecurityException::new);
 
             String password = UUID.randomUUID().toString().toLowerCase();
             clientService.resetClientPassword(client, password);
@@ -51,9 +53,9 @@ public class AuthInitController {
 
             OAuth2RestTemplate oAuth2RestTemplate = templateFactory.create(client.getName(), password, client.getClientId(), clientSecret);
 
-            accessTokenRepository.addAccessToken(testRequest.getClient(), oAuth2RestTemplate.getAccessToken());
+            accessTokenRepository.addAccessToken(orgName, oAuth2RestTemplate.getAccessToken());
 
-            System.out.println("accessTokenRepository.getAccessToken() = " + accessTokenRepository.getAccessToken(testRequest.getClient()));
+            System.out.println("accessTokenRepository.getAccessToken() = " + accessTokenRepository.getAccessToken(orgName));
         }
         return ResponseEntity.noContent().build();
     }
@@ -63,9 +65,9 @@ public class AuthInitController {
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Sorry, men vi finner ikke klienten du valgte!");
     }
 
-    @GetMapping("/clear/{orgName}") // TODO should be a POST request
+    @DeleteMapping("/clear")
     public ResponseEntity<Void> clearAuthorizations(@PathVariable String orgName) {
-        accessTokenRepository.clearAccessTokens(orgName);
+        accessTokenRepository.deleteAccessToken(orgName);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/no/fint/testrunner/controller/BasicTestController.java
+++ b/src/main/java/no/fint/testrunner/controller/BasicTestController.java
@@ -13,16 +13,17 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @CrossOrigin
 @Api(value = "Basic Tests")
-@RequestMapping("/api/tests/basic")
+@RequestMapping("/api/tests/{orgName}/basic")
 public class BasicTestController {
 
     @Autowired
     private BasicTestService basicTestService;
 
     @PostMapping
-    public ResponseEntity<BasicTestResult> startBasicTest(@RequestBody TestRequest testRequest) {
+    public ResponseEntity<BasicTestResult> startBasicTest(@PathVariable String orgName,
+                                                          @RequestBody TestRequest testRequest) {
         log.info("Starting basic test...");
-        BasicTestResult basicTestResult = basicTestService.runBasicTest(testRequest);
+        BasicTestResult basicTestResult = basicTestService.runBasicTest(orgName, testRequest);
         log.info("Ending basic test...");
 
         return ResponseEntity.ok().body(basicTestResult);

--- a/src/main/java/no/fint/testrunner/controller/HealthTestController.java
+++ b/src/main/java/no/fint/testrunner/controller/HealthTestController.java
@@ -13,17 +13,18 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @CrossOrigin
 @Api(value = "Health Tests")
-@RequestMapping("/api/tests/health")
+@RequestMapping("/api/tests/{orgName}/health")
 public class HealthTestController {
 
     @Autowired
     private HealthTestService healthTestService;
 
     @PostMapping
-    public ResponseEntity<HealthTestCase> startHealthTest(@RequestBody TestRequest testRequest) {
+    public ResponseEntity<HealthTestCase> startHealthTest(@PathVariable String orgName,
+                                                          @RequestBody TestRequest testRequest) {
 
         log.info("Starting health test...");
-        HealthTestCase healthTestCase = healthTestService.runHealthTest(testRequest);
+        HealthTestCase healthTestCase = healthTestService.runHealthTest(orgName, testRequest);
         log.info("Ending health test...");
 
         return ResponseEntity.ok().body(healthTestCase);

--- a/src/main/java/no/fint/testrunner/model/TestRequest.java
+++ b/src/main/java/no/fint/testrunner/model/TestRequest.java
@@ -17,7 +17,6 @@ public class TestRequest {
 
     private String baseUrl;
     private String endpoint;
-    private String client;
 
     @JsonIgnore
     public String getTarget(String resource) {

--- a/src/main/java/no/fint/testrunner/service/AccessTokenRepository.java
+++ b/src/main/java/no/fint/testrunner/service/AccessTokenRepository.java
@@ -24,7 +24,6 @@ public class AccessTokenRepository {
         return tokenCache.put(key, value);
     }
 
-    // TODO key == organisationName?
     public void deleteAccessToken(String key) {
         tokenCache.remove(key);
     }

--- a/src/main/java/no/fint/testrunner/service/AccessTokenRepository.java
+++ b/src/main/java/no/fint/testrunner/service/AccessTokenRepository.java
@@ -25,16 +25,7 @@ public class AccessTokenRepository {
     }
 
     // TODO key == organisationName?
-    public void clearAccessTokens(String organisationName) {
-        ConcurrentMap<String, OAuth2AccessToken> tempTokeCache = new ConcurrentSkipListMap<>();
-
-        tokenCache.forEach((s, oAuth2AccessToken) -> {
-            if (s.contains(organisationName)) {
-                tempTokeCache.put(s, oAuth2AccessToken);
-            }
-        });
-        tempTokeCache.forEach((s, oAuth2AccessToken) -> {
-            tokenCache.remove(s, oAuth2AccessToken);
-        });
+    public void deleteAccessToken(String key) {
+        tokenCache.remove(key);
     }
 }

--- a/src/main/java/no/fint/testrunner/service/BasicTestService.java
+++ b/src/main/java/no/fint/testrunner/service/BasicTestService.java
@@ -32,9 +32,9 @@ public class BasicTestService {
 
     private HttpHeaders headers;
 
-    public BasicTestResult runBasicTest(TestRequest testRequest) {
+    public BasicTestResult runBasicTest(String orgName, TestRequest testRequest) {
 
-        OAuth2AccessToken accessToken = accessTokenRepository.getAccessToken(testRequest.getClient());
+        OAuth2AccessToken accessToken = accessTokenRepository.getAccessToken(orgName);
 
         if (Pwf.isPwf(testRequest.getBaseUrl())) {
             headers = Headers.createPwfHeaders();

--- a/src/main/java/no/fint/testrunner/service/BasicTestService.java
+++ b/src/main/java/no/fint/testrunner/service/BasicTestService.java
@@ -67,11 +67,11 @@ public class BasicTestService {
     private long getSize(TestRequest testRequest, String resource) {
         String url = String.format("%s/cache/size", testRequest.getTarget(resource));
 
-        log.info(url);
-
         try {
             ResponseEntity<BasicTestSize> response = restTemplate.exchange(url, HttpMethod.GET, new HttpEntity<>(headers), BasicTestSize.class);
-            return response.getBody().getSize();
+            final long size = response.getBody().getSize();
+            log.info("{} = {}", url, size);
+            return size;
         } catch (RestClientException e) {
             return -1;
         }
@@ -79,11 +79,12 @@ public class BasicTestService {
 
     private long getLastUpdated(TestRequest testRequest, String resource) {
         String url = String.format("%s/last-updated", testRequest.getTarget(resource));
-        log.info(url);
 
         try {
             ResponseEntity<BasicTestLastUpdated> response = restTemplate.exchange(url, HttpMethod.GET, new HttpEntity<>(headers), BasicTestLastUpdated.class);
-            return response.getBody().getLastUpdated();
+            final long lastUpdated = response.getBody().getLastUpdated();
+            log.info("{} = {}", url, lastUpdated);
+            return lastUpdated;
         } catch (RestClientException e) {
             return -1;
         }

--- a/src/main/java/no/fint/testrunner/service/HealthTestService.java
+++ b/src/main/java/no/fint/testrunner/service/HealthTestService.java
@@ -33,7 +33,7 @@ public class HealthTestService {
     @Autowired
     private AccessTokenRepository accessTokenRepository;
 
-    public HealthTestCase runHealthTest(TestRequest testRequest) {
+    public HealthTestCase runHealthTest(String orgName, TestRequest testRequest) {
 
         HttpHeaders headers;
         ResponseEntity<Event<Health>> response;
@@ -42,7 +42,7 @@ public class HealthTestService {
         if (Pwf.isPwf(testRequest.getBaseUrl())) {
             headers = Headers.createPwfHeaders();
         } else {
-            headers = Headers.createHeaders(accessTokenRepository.getAccessToken(testRequest.getClient()).getValue());
+            headers = Headers.createHeaders(accessTokenRepository.getAccessToken(orgName).getValue());
         }
 
 

--- a/src/test/groovy/no/fint/testrunner/controller/AuthInitControllerSpec.groovy
+++ b/src/test/groovy/no/fint/testrunner/controller/AuthInitControllerSpec.groovy
@@ -49,7 +49,7 @@ class AuthInitControllerSpec extends MockMvcSpecification {
                 .contentType(MediaType.APPLICATION_JSON_UTF8).content(JsonOutput.toJson(request)))
 
         then:
-        1 * clientService.getClientByDn('client') >> Optional.of(new Client(name: 'name', clientId: 'client-id'))
+        1 * clientService.getClient('client', 'orgName') >> Optional.of(new Client(name: 'name', clientId: 'client-id'))
         1 * clientService.getClientSecret(_ as Client) >> 'very-secret'
         1 * templateFactory.create('name', _ as String, 'client-id', 'very-secret') >> restTemplate
         1 * restTemplate.getAccessToken() >> Mock(OAuth2AccessToken)

--- a/src/test/groovy/no/fint/testrunner/controller/AuthInitControllerSpec.groovy
+++ b/src/test/groovy/no/fint/testrunner/controller/AuthInitControllerSpec.groovy
@@ -35,17 +35,17 @@ class AuthInitControllerSpec extends MockMvcSpecification {
 
     def "Clear authorizations"() {
         when:
-        def response = mockMvc.perform(get('/api/tests/auth/clear/orgName'))
+        def response = mockMvc.perform(delete('/api/tests/orgName/auth/clear'))
 
         then:
-        1 * accessTokenRepository.clearAccessTokens('orgName')
+        1 * accessTokenRepository.deleteAccessToken('orgName')
         response.andExpect(status().isNoContent())
     }
 
     def 'Auth init'() {
         when:
-        def request = new TestRequest(baseUrl: '/base', endpoint: '/endpoint', client: 'client')
-        def response = mockMvc.perform(post('/api/tests/auth/init')
+        def request = new TestRequest(baseUrl: '/base', endpoint: '/endpoint')
+        def response = mockMvc.perform(post('/api/tests/orgName/auth/init/client')
                 .contentType(MediaType.APPLICATION_JSON_UTF8).content(JsonOutput.toJson(request)))
 
         then:
@@ -53,7 +53,7 @@ class AuthInitControllerSpec extends MockMvcSpecification {
         1 * clientService.getClientSecret(_ as Client) >> 'very-secret'
         1 * templateFactory.create('name', _ as String, 'client-id', 'very-secret') >> restTemplate
         1 * restTemplate.getAccessToken() >> Mock(OAuth2AccessToken)
-        1 * accessTokenRepository.addAccessToken('client', _ as OAuth2AccessToken)
+        1 * accessTokenRepository.addAccessToken('orgName', _ as OAuth2AccessToken)
         response.andExpect(status().isNoContent())
     }
 }

--- a/src/test/groovy/no/fint/testrunner/controller/BasicTestControllerSpec.groovy
+++ b/src/test/groovy/no/fint/testrunner/controller/BasicTestControllerSpec.groovy
@@ -21,16 +21,16 @@ class BasicTestControllerSpec extends MockMvcSpecification {
 
     def "Start basic test and get test result"() {
         given:
-        def request = new TestRequest('http://localhost', '/test', 'client')
+        def request = new TestRequest('http://localhost', '/test')
         def json = JsonOutput.toJson(request)
 
         when:
-        def response = mockMvc.perform(post('/api/tests/basic')
+        def response = mockMvc.perform(post('/api/tests/orgName/basic')
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(json))
 
         then:
-        1 * service.runBasicTest(request) >> new BasicTestResult(message: 'test result')
+        1 * service.runBasicTest('orgName', request) >> new BasicTestResult(message: 'test result')
         response.andExpect(status().isOk())
                 .andExpect(jsonPathEquals('$.message', 'test result'))
     }

--- a/src/test/groovy/no/fint/testrunner/controller/HealthTestControllerSpec.groovy
+++ b/src/test/groovy/no/fint/testrunner/controller/HealthTestControllerSpec.groovy
@@ -21,16 +21,16 @@ class HealthTestControllerSpec extends MockMvcSpecification {
 
     def "Start health test and get test result"() {
         given:
-        def request = new TestRequest('http://localhost', '/test', 'client')
+        def request = new TestRequest('http://localhost', '/test')
         def json = JsonOutput.toJson(request)
 
         when:
-        def response = mockMvc.perform(post('/api/tests/health')
+        def response = mockMvc.perform(post('/api/tests/orgName/health')
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(json))
 
         then:
-        1 * service.runHealthTest(request) >> new HealthTestCase(message: 'test result')
+        1 * service.runHealthTest('orgName', request) >> new HealthTestCase(message: 'test result')
         response.andExpect(status().isOk())
                 .andExpect(jsonPathEquals('$.message', 'test result'))
     }

--- a/src/test/groovy/no/fint/testrunner/model/TestRequestSpec.groovy
+++ b/src/test/groovy/no/fint/testrunner/model/TestRequestSpec.groovy
@@ -6,7 +6,7 @@ class TestRequestSpec extends Specification {
 
     def "Get target given empty baseUrl returns url with default base"() {
         when:
-        def target = new TestRequest('', '/test', 'client').getTarget('resource')
+        def target = new TestRequest('', '/test').getTarget('resource')
 
         then:
         target == "${TestRequest.DEFAULT_BASE_URL}/test/resource"
@@ -14,7 +14,7 @@ class TestRequestSpec extends Specification {
 
     def "Get target given baseUrl returns url"() {
         when:
-        def target = new TestRequest('http://localhost', '/test', 'client').getTarget('resource')
+        def target = new TestRequest('http://localhost', '/test').getTarget('resource')
 
         then:
         target == 'http://localhost/test/resource'

--- a/src/test/groovy/no/fint/testrunner/service/AccessTokenRepositorySpec.groovy
+++ b/src/test/groovy/no/fint/testrunner/service/AccessTokenRepositorySpec.groovy
@@ -28,7 +28,7 @@ class AccessTokenRepositorySpec extends Specification {
         repository.addAccessToken('key1', Mock(OAuth2AccessToken))
 
         when:
-        repository.clearAccessTokens('key1')
+        repository.deleteAccessToken('key1')
         def token = repository.getAccessToken('key1')
 
         then:

--- a/src/test/groovy/no/fint/testrunner/service/BasicTestServiceSpec.groovy
+++ b/src/test/groovy/no/fint/testrunner/service/BasicTestServiceSpec.groovy
@@ -21,7 +21,7 @@ class BasicTestServiceSpec extends Specification {
 
     void setup() {
         AccessTokenRepository accessTokenRepository = Mock() {
-            getAccessToken('client') >> Mock(OAuth2AccessToken) {
+            getAccessToken('orgName') >> Mock(OAuth2AccessToken) {
                 getValue() >> 'token'
             }
         }
@@ -40,10 +40,10 @@ class BasicTestServiceSpec extends Specification {
 
         def cacheSize = JsonOutput.toJson(new BasicTestSize(size: 5))
         mockServer.expect(requestTo('http://localhost/test/test-resource/cache/size')).andRespond(withSuccess(cacheSize, MediaType.APPLICATION_JSON))
-        def testRequest = new TestRequest('http://localhost', '/test', 'client')
+        def testRequest = new TestRequest('http://localhost', '/test')
 
         when:
-        def result = service.runBasicTest(testRequest)
+        def result = service.runBasicTest('orgName', testRequest)
 
         then:
         1 * endpointResourcesService.getEndpointResources('/test') >> Optional.of(['test-resource'])

--- a/src/test/groovy/no/fint/testrunner/service/HealthTestServiceSpec.groovy
+++ b/src/test/groovy/no/fint/testrunner/service/HealthTestServiceSpec.groovy
@@ -22,7 +22,7 @@ class HealthTestServiceSpec extends Specification {
 
     void setup() {
         AccessTokenRepository accessTokenRepository = Mock() {
-            getAccessToken('client') >> Mock(OAuth2AccessToken) {
+            getAccessToken('orgName') >> Mock(OAuth2AccessToken) {
                 getValue() >> 'token'
             }
         }
@@ -36,12 +36,12 @@ class HealthTestServiceSpec extends Specification {
 
     def "Run health test on non-pwf url with no health data"() {
         given:
-        def testRequest = new TestRequest('http://localhost', '/test', 'client')
+        def testRequest = new TestRequest('http://localhost', '/test')
         def healthEvent = JsonOutput.toJson(new Event<Health>())
         mockServer.expect(requestTo('http://localhost/test/admin/health')).andRespond(withSuccess(healthEvent, MediaType.APPLICATION_JSON))
 
         when:
-        def result = service.runHealthTest(testRequest)
+        def result = service.runHealthTest('orgName', testRequest)
 
         then:
         mockServer.verify()
@@ -50,12 +50,12 @@ class HealthTestServiceSpec extends Specification {
 
     def "Run health test on non-pwf url with healthy response from adapter"() {
         given:
-        def testRequest = new TestRequest('http://localhost', '/test', 'client')
+        def testRequest = new TestRequest('http://localhost', '/test')
         def healthEvent = JsonOutput.toJson(new Event<Health>(data: [new Health(status: HealthStatus.APPLICATION_HEALTHY.name())]))
         mockServer.expect(requestTo('http://localhost/test/admin/health')).andRespond(withSuccess(healthEvent, MediaType.APPLICATION_JSON))
 
         when:
-        def result = service.runHealthTest(testRequest)
+        def result = service.runHealthTest('orgName', testRequest)
 
         then:
         mockServer.verify()
@@ -64,12 +64,12 @@ class HealthTestServiceSpec extends Specification {
 
     def "Run health test on non-pwf url with unhealthy response from adapter"() {
         given:
-        def testRequest = new TestRequest('http://localhost', '/test', 'client')
+        def testRequest = new TestRequest('http://localhost', '/test')
         def healthEvent = JsonOutput.toJson(new Event<Health>(data: [new Health(status: HealthStatus.APPLICATION_UNHEALTHY.name())]))
         mockServer.expect(requestTo('http://localhost/test/admin/health')).andRespond(withSuccess(healthEvent, MediaType.APPLICATION_JSON))
 
         when:
-        def result = service.runHealthTest(testRequest)
+        def result = service.runHealthTest('orgName', testRequest)
 
         then:
         mockServer.verify()


### PR DESCRIPTION
API is now based at `/api/tests/{orgName}`
Remove client from TestRequest, this is now part of the request URI.
AccessTokenRepository is keyed by organisation name instead of client dn.
